### PR TITLE
fix(dicts): lazily set up cipher in values()/items()

### DIFF
--- a/beaver/dicts.py
+++ b/beaver/dicts.py
@@ -290,6 +290,8 @@ class AsyncBeaverDict[T: BaseModel](AsyncBeaverBase[T], IAsyncBeaverDict[T]):
             yield row["key"]
 
     async def values(self):
+        if self._secret_arg and not self._cipher:
+            await self._setup_security(self._secret_arg)
         cursor = await self.connection.execute(
             "SELECT value FROM __beaver_dicts__ WHERE dict_name = ?", (self._name,)
         )
@@ -297,6 +299,8 @@ class AsyncBeaverDict[T: BaseModel](AsyncBeaverBase[T], IAsyncBeaverDict[T]):
             yield self._deserialize(row["value"])
 
     async def items(self):
+        if self._secret_arg and not self._cipher:
+            await self._setup_security(self._secret_arg)
         cursor = await self.connection.execute(
             "SELECT key, value FROM __beaver_dicts__ WHERE dict_name = ?", (self._name,)
         )

--- a/tests/unit/test_dicts.py
+++ b/tests/unit/test_dicts.py
@@ -219,3 +219,36 @@ async def test_dict_jsonl_dump_requires_fp(async_db_mem: AsyncBeaverDB):
     await d.set("a", 1)
     with pytest.raises(ValueError):
         await d.dump(format="jsonl")
+
+
+async def test_encrypted_dict_iteration_as_first_op_decrypts(db_path):
+    """
+    Regression: values()/items() must lazily set up the Fernet cipher the same
+    way get()/set() do. If the first operation on a freshly-opened encrypted
+    dict is an iteration, the cipher was never initialised, so values were
+    yielded as raw ciphertext instead of decrypted objects.
+    """
+    secret = "s3cr3t-master-key"
+
+    db1 = AsyncBeaverDB(db_path)
+    await db1.connect()
+    d1 = db1.dict("vault", secret=secret)
+    await d1.set("k1", {"v": 1})
+    await d1.set("k2", {"v": 2})
+    await db1.close()
+
+    # Fresh db instance — singleton cache is empty, cipher is None until set up.
+    db2 = AsyncBeaverDB(db_path)
+    await db2.connect()
+    d2 = db2.dict("vault", secret=secret)
+    # FIRST op is iteration (no prior get/set on this handle).
+    vals = sorted([v["v"] async for v in d2.values()])
+    assert vals == [1, 2]
+    await db2.close()
+
+    db3 = AsyncBeaverDB(db_path)
+    await db3.connect()
+    d3 = db3.dict("vault", secret=secret)
+    items = sorted([(k, v["v"]) async for k, v in d3.items()])
+    assert items == [("k1", 1), ("k2", 2)]
+    await db3.close()


### PR DESCRIPTION
## Summary

`get()`/`set()` lazily call `_setup_security()` when an encrypted dict's Fernet
cipher is not yet initialised, but `values()`/`items()` did not. If the **first**
operation on a freshly-opened encrypted dict is an iteration (e.g. a `count`/scan
helper), the cipher was never set up, so values were yielded as **raw base64
ciphertext** instead of decrypted objects — `json.loads` / `model_validate_json`
then fails with `JSONDecodeError`.

Applied the same lazy guard used by `get()`/`set()` to `values()` and `items()`.

## Impact

Surfaced downstream in `warden` (pinned to this checkout): `warden init`
iterates `users.values()` as its first storage op in a fresh process and crashed
with "Invalid JSON". Also would have broken every `warden` VS2 feature that
scans `.values()` (`/me`, `/sessions/lookup`, service-token lookup).

## Test plan

- [x] New regression test: reopen a file-backed db, iterate `values()`/`items()`
      as the first op on an encrypted dict — asserts decrypted output.
- [x] `make test-unit` — 131 passed.
- [x] `black --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)